### PR TITLE
Fix #154 - relay dies with AssertionError

### DIFF
--- a/relay-java/src/main/java/com/genymobile/gnirehtet/relay/Relay.java
+++ b/relay-java/src/main/java/com/genymobile/gnirehtet/relay/Relay.java
@@ -53,11 +53,9 @@ public class Relay {
             Set<SelectionKey> selectedKeys = selector.selectedKeys();
 
             long now = System.currentTimeMillis();
-            if (now >= nextCleaningDeadline) {
+            if (now >= nextCleaningDeadline || selectedKeys.isEmpty()) {
                 tunnelServer.cleanUp();
                 nextCleaningDeadline = now + CLEANING_INTERVAL;
-            } else if (selectedKeys.isEmpty()) {
-                throw new AssertionError("selector.select() returned without any event, an invalid SelectionKey was probably been registered");
             }
 
             for (SelectionKey selectedKey : selectedKeys) {


### PR DESCRIPTION
Fix race condition in the Java relay implementation due to timeout from no activity, it misses the cleaning deadline by a small number of milliseconds, and throws an exception because there are no open selectors. 

Fixes https://github.com/Genymobile/gnirehtet/issues/154

Evidence/log: 
Used an additional print statement printing out the relevant variables and changed the original exception to a print

```
Selected keys size 1 now: 1562790544556 nextCleaningDeadline 1562790662669
Selected keys size 0 now: 1562790662667 nextCleaningDeadline 1562790662669
selector.select() returned without any event, an invalid SelectionKey was probably been registered
Selected keys size 0 now: 1562790662670 nextCleaningDeadline 1562790662669
Selected keys size 0 now: 1562790722672 nextCleaningDeadline 1562790722670
```

The print statement used was 

```
System.out.println("Selected keys size " + selectedKeys.size() + " now: " + now + " nextCleaningDeadline " + nextCleaningDeadline);
```
Add this before line 56 of Genymoble:master Relay.java if you want to recreate it

Environment - java relay running on macOS 10.14