### PR TITLE
Add port option to allow multiple instances of the gnirehtet relay to run 

### DIFF
--- a/relay-java/src/main/java/com/genymobile/gnirehtet/CommandLineArguments.java
+++ b/relay-java/src/main/java/com/genymobile/gnirehtet/CommandLineArguments.java
@@ -16,6 +16,8 @@
 
 package com.genymobile.gnirehtet;
 
+import com.genymobile.gnirehtet.relay.Relay;
+
 /**
  * Simple specific command-line arguments parser.
  */
@@ -25,7 +27,8 @@ public class CommandLineArguments {
     public static final int PARAM_SERIAL = 1;
     public static final int PARAM_DNS_SERVER = 1 << 1;
     public static final int PARAM_ROUTES = 1 << 2;
-
+    public static final int PARAM_PORT = 1 << 3;
+    private int port = Relay.DEFAULT_PORT;
     private String serial;
     private String dnsServers;
     private String routes;
@@ -52,6 +55,16 @@ public class CommandLineArguments {
                 }
                 arguments.routes = args[i + 1];
                 ++i; // consume the -r parameter
+            } else if ((acceptedParameters & PARAM_PORT) != 0 && "-p".equals(arg)) {
+                if (arguments.routes != null) {
+                    throw new IllegalArgumentException("Port already set");
+                }
+
+                if (i == args.length -1) {
+                    throw new IllegalArgumentException("Missing -p parameter");
+                }
+                arguments.port = Integer.parseInt(args[i + 1]);
+                ++i;
             } else if ((acceptedParameters & PARAM_SERIAL) != 0 && arguments.serial == null) {
                 arguments.serial = arg;
             } else {
@@ -71,5 +84,9 @@ public class CommandLineArguments {
 
     public String getRoutes() {
         return routes;
+    }
+
+    public int getPort() {
+        return port;
     }
 }

--- a/relay-java/src/main/java/com/genymobile/gnirehtet/Main.java
+++ b/relay-java/src/main/java/com/genymobile/gnirehtet/Main.java
@@ -76,7 +76,7 @@ public final class Main {
                 cmdReinstall(args.getSerial());
             }
         },
-        RUN("run", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES) {
+        RUN("run", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT) {
             @Override
             String getDescription() {
                 return "Enable reverse tethering for exactly one device:\n"
@@ -88,10 +88,10 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdRun(args.getSerial(), args.getDnsServers(), args.getRoutes());
+                cmdRun(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort());
             }
         },
-        AUTORUN("autorun", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES) {
+        AUTORUN("autorun", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT) {
             @Override
             String getDescription() {
                 return "Enable reverse tethering for all devices:\n"
@@ -101,10 +101,10 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdAutorun(args.getDnsServers(), args.getRoutes());
+                cmdAutorun(args.getDnsServers(), args.getRoutes(), args.getPort());
             }
         },
-        START("start", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES) {
+        START("start", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT) {
             @Override
             String getDescription() {
                 return "Start a client on the Android device and exit.\n"
@@ -113,6 +113,7 @@ public final class Main {
                         + "If -d is given, then make the Android device use the specified\n"
                         + "DNS server(s). Otherwise, use 8.8.8.8 (Google public DNS).\n"
                         + "If -r is given, then only reverse tether the specified routes.\n"
+                        + "If -p is given, the exposed port is set. Defaults to 31416.\n"
                         + "Otherwise, use 0.0.0.0/0 (redirect the whole traffic).\n"
                         + "If the client is already started, then do nothing, and ignore\n"
                         + "the other parameters.\n"
@@ -121,10 +122,10 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdStart(args.getSerial(), args.getDnsServers(), args.getRoutes());
+                cmdStart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort());
             }
         },
-        AUTOSTART("autostart", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES) {
+        AUTOSTART("autostart", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT) {
             @Override
             String getDescription() {
                 return "Listen for device connexions and start a client on every detected\n"
@@ -135,7 +136,7 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdAutostart(args.getDnsServers(), args.getRoutes());
+                cmdAutostart(args.getDnsServers(), args.getRoutes(), args.getPort());
             }
         },
         STOP("stop", CommandLineArguments.PARAM_SERIAL) {
@@ -151,7 +152,7 @@ public final class Main {
                 cmdStop(args.getSerial());
             }
         },
-        RESTART("restart", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES) {
+        RESTART("restart", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT) {
             @Override
             String getDescription() {
                 return "Stop then start.";
@@ -159,10 +160,10 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdRestart(args.getSerial(), args.getDnsServers(), args.getRoutes());
+                cmdRestart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort());
             }
         },
-        TUNNEL("tunnel", CommandLineArguments.PARAM_SERIAL) {
+        TUNNEL("tunnel", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_PORT) {
             @Override
             String getDescription() {
                 return "Set up the 'adb reverse' tunnel.\n"
@@ -173,10 +174,10 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdTunnel(args.getSerial());
+                cmdTunnel(args.getSerial(), args.getPort());
             }
         },
-        RELAY("relay", CommandLineArguments.PARAM_NONE) {
+        RELAY("relay", CommandLineArguments.PARAM_PORT) {
             @Override
             String getDescription() {
                 return "Start the relay server in the current terminal.";
@@ -184,7 +185,7 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdRelay();
+                cmdRelay(args.getPort());
             }
         };
 
@@ -216,9 +217,9 @@ public final class Main {
         cmdInstall(serial);
     }
 
-    private static void cmdRun(String serial, String dnsServers, String routes) throws InterruptedException, IOException, CommandExecutionException {
+    private static void cmdRun(String serial, String dnsServers, String routes, int port) throws InterruptedException, IOException, CommandExecutionException {
         // start in parallel so that the relay server is ready when the client connects
-        asyncStart(serial, dnsServers, routes);
+        asyncStart(serial, dnsServers, routes, port);
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             // executed on Ctrl+C
@@ -229,23 +230,23 @@ public final class Main {
             }
         }));
 
-        cmdRelay();
+        cmdRelay(port);
     }
 
-    private static void cmdAutorun(final String dnsServers, final String routes) throws InterruptedException, IOException, CommandExecutionException {
+    private static void cmdAutorun(final String dnsServers, final String routes, int port) throws InterruptedException, IOException, CommandExecutionException {
         new Thread(() -> {
             try {
-                cmdAutostart(dnsServers, routes);
+                cmdAutostart(dnsServers, routes, port);
             } catch (Exception e) {
                 Log.e(TAG, "Cannot auto start clients", e);
             }
         }).start();
 
-        cmdRelay();
+        cmdRelay(port);
     }
 
     @SuppressWarnings("checkstyle:MagicNumber")
-    private static void cmdStart(String serial, String dnsServers, String routes) throws InterruptedException, IOException,
+    private static void cmdStart(String serial, String dnsServers, String routes, int port) throws InterruptedException, IOException,
             CommandExecutionException {
         if (mustInstallClient(serial)) {
             cmdInstall(serial);
@@ -254,7 +255,7 @@ public final class Main {
         }
 
         Log.i(TAG, "Starting client...");
-        cmdTunnel(serial);
+        cmdTunnel(serial, port);
 
         List<String> cmd = new ArrayList<>();
         Collections.addAll(cmd, "shell", "am", "broadcast", "-a", "com.genymobile.gnirehtet.START", "-n",
@@ -268,9 +269,9 @@ public final class Main {
         execAdb(serial, cmd);
     }
 
-    private static void cmdAutostart(final String dnsServers, final String routes) {
+    private static void cmdAutostart(final String dnsServers, final String routes, int port) {
         AdbMonitor adbMonitor = new AdbMonitor((serial) -> {
-            asyncStart(serial, dnsServers, routes);
+            asyncStart(serial, dnsServers, routes, port);
         });
         adbMonitor.monitor();
     }
@@ -281,14 +282,14 @@ public final class Main {
                 "com.genymobile.gnirehtet/.GnirehtetControlReceiver");
     }
 
-    private static void cmdRestart(String serial, String dnsServers, String routes) throws InterruptedException, IOException,
+    private static void cmdRestart(String serial, String dnsServers, String routes, int port) throws InterruptedException, IOException,
             CommandExecutionException {
         cmdStop(serial);
-        cmdStart(serial, dnsServers, routes);
+        cmdStart(serial, dnsServers, routes, port);
     }
 
-    private static void cmdTunnel(String serial) throws InterruptedException, IOException, CommandExecutionException {
-        execAdb(serial, "reverse", "localabstract:gnirehtet", "tcp:31416");
+    private static void cmdTunnel(String serial, int port) throws InterruptedException, IOException, CommandExecutionException {
+        execAdb(serial, "reverse", "localabstract:gnirehtet", "tcp:" + port);
     }
 
     private static void cmdRelay() throws IOException {
@@ -296,10 +297,15 @@ public final class Main {
         new Relay().run();
     }
 
-    private static void asyncStart(String serial, String dnsServers, String routes) {
+    private static void cmdRelay(int port) throws IOException {
+        Log.i(TAG, "Starting relay server w/ custom port...");
+        new Relay(port).run();
+    }
+
+    private static void asyncStart(String serial, String dnsServers, String routes, int port) {
         new Thread(() -> {
             try {
-                cmdStart(serial, dnsServers, routes);
+                cmdStart(serial, dnsServers, routes, port);
             } catch (Exception e) {
                 Log.e(TAG, "Cannot start client", e);
             }

--- a/relay-java/src/main/java/com/genymobile/gnirehtet/relay/Relay.java
+++ b/relay-java/src/main/java/com/genymobile/gnirehtet/relay/Relay.java
@@ -25,7 +25,7 @@ public class Relay {
 
     private static final String TAG = Relay.class.getSimpleName();
 
-    private static final int DEFAULT_PORT = 31416;
+    public static final int DEFAULT_PORT = 31416;
     private static final int CLEANING_INTERVAL = 60 * 1000;
 
     private final int port;

--- a/relay-rust/src/cli_args.rs
+++ b/relay-rust/src/cli_args.rs
@@ -18,11 +18,13 @@ pub const PARAM_NONE: u8 = 0;
 pub const PARAM_SERIAL: u8 = 1;
 pub const PARAM_DNS_SERVERS: u8 = 1 << 1;
 pub const PARAM_ROUTES: u8 = 1 << 2;
+pub const PARAM_PORT: u8 = 1 << 3;
 
 pub struct CommandLineArguments {
     serial: Option<String>,
     dns_servers: Option<String>,
     routes: Option<String>,
+    pub port: u16,
 }
 
 impl CommandLineArguments {
@@ -31,6 +33,7 @@ impl CommandLineArguments {
         let mut serial = None;
         let mut dns_servers = None;
         let mut routes = None;
+        let mut port = 31416;
 
         let mut iter = args.into_iter();
         while let Some(arg) = iter.next() {
@@ -53,6 +56,12 @@ impl CommandLineArguments {
                 } else {
                     return Err(String::from("Missing -r parameter"));
                 }
+            } else if (accepted_parameters & PARAM_PORT) != 0 && "-p" == arg {
+                if let Some(value) = iter.next() {
+                    port = value.into().parse().unwrap()
+                } else {
+                    return Err(String::from("Missing -p parameter"));
+                }
             } else if (accepted_parameters & PARAM_SERIAL) != 0 && serial.is_none() {
                 serial = Some(arg);
             } else {
@@ -63,6 +72,7 @@ impl CommandLineArguments {
             serial,
             dns_servers,
             routes,
+            port
         })
     }
 

--- a/relay-rust/src/lib.rs
+++ b/relay-rust/src/lib.rs
@@ -20,7 +20,6 @@ pub use crate::relay::byte_buffer;
 use crate::relay::Relay;
 use std::io;
 
-pub fn relay() -> io::Result<()> {
-    const PORT: u16 = 31416;
-    Relay::new(PORT).run()
+pub fn relay(port: u16) -> io::Result<()> {
+    Relay::new(port).run()
 }


### PR DESCRIPTION
Related to https://github.com/Genymobile/gnirehtet/issues/179 but I have a use case for running multiple instances. 

In my use case, I need to be able to send traffic to different proxies for different phones. I currently run gnirehtet with proxychains to do this. This added -p option lets me run multiple instances of the relay on the same computer. 

It was useful for what I'm doing so I thought I'd try to get it upstream to see if it helps anyone else.

I added the option to both the Java and Rust versions to keep the versions consistent. I'm not super familiar with Rust so if there are any conventions I missed, let me know. 