### PR TITLE
Allow to set a custom path for client APK

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,20 @@ To stop a client:
         -n com.genymobile.gnirehtet/.GnirehtetActivity
 
 
+## Environment variables
+
+`ADB` defines a custom path to the `adb` executable:
+
+```bash
+ADB=/path/to/my/adb ./gnirehtet run
+```
+
+`GNIREHTET_APK` defines a custom path to `gnirehtet.apk`:
+
+```bash
+GNIREHTET_APK=/usr/share/gnirehtet/gnirehtet.apk ./gnirehtet run
+```
+
 ## Why _gnirehtet_?
 
     rev <<< tethering

--- a/relay-java/src/main/java/com/genymobile/gnirehtet/Main.java
+++ b/relay-java/src/main/java/com/genymobile/gnirehtet/Main.java
@@ -38,6 +38,16 @@ public final class Main {
         // not instantiable
     }
 
+    private static String getAdbPath() {
+        String adb = System.getenv("ADB");
+        return adb != null ? adb : "adb";
+    }
+
+    private static String getApkPath() {
+        String apk = System.getenv("GNIREHTET_APK");
+        return apk != null ? apk : "gnirehtet.apk";
+    }
+
     enum Command {
         INSTALL("install", CommandLineArguments.PARAM_SERIAL) {
             @Override
@@ -208,7 +218,7 @@ public final class Main {
 
     private static void cmdInstall(String serial) throws InterruptedException, IOException, CommandExecutionException {
         Log.i(TAG, "Installing gnirehtet client...");
-        execAdb(serial, "install", "-r", "gnirehtet.apk");
+        execAdb(serial, "install", "-r", getApkPath());
     }
 
     private static void cmdUninstall(String serial) throws InterruptedException, IOException, CommandExecutionException {

--- a/relay-rust/src/main.rs
+++ b/relay-rust/src/main.rs
@@ -36,6 +36,24 @@ use std::time::Duration;
 const TAG: &str = "Main";
 const REQUIRED_APK_VERSION_CODE: &str = "7";
 
+#[inline]
+fn get_adb_path() -> String {
+    if let Some(env_adb) = std::env::var_os("ADB") {
+        env_adb.into_string().expect("invalid ADB value")
+    } else {
+        "adb".to_string()
+    }
+}
+
+#[inline]
+fn get_apk_path() -> String {
+    if let Some(env_adb) = std::env::var_os("GNIREHTET_APK") {
+        env_adb.into_string().expect("invalid GNIREHTET_APK value")
+    } else {
+        "gnirehtet.apk".to_string()
+    }
+}
+
 const COMMANDS: &[&dyn Command] = &[
     &InstallCommand,
     &UninstallCommand,
@@ -325,7 +343,7 @@ impl Command for RelayCommand {
 
 fn cmd_install(serial: Option<&str>) -> Result<(), CommandExecutionError> {
     info!(target: TAG, "Installing gnirehtet client...");
-    exec_adb(serial, vec!["install", "-r", "gnirehtet.apk"])
+    exec_adb(serial, vec!["install".into(), "-r".into(), get_apk_path()])
 }
 
 fn cmd_uninstall(serial: Option<&str>) -> Result<(), CommandExecutionError> {


### PR DESCRIPTION
Use the environment variable GNIREHTET_APK to use a custom path for the gnirehtet client.

Ref <https://github.com/Genymobile/gnirehtet/issues/90>