### PR TITLE
 should update interest after process_send immediately

### DIFF
--- a/relay-rust/src/relay/tcp_connection.rs
+++ b/relay-rust/src/relay/tcp_connection.rs
@@ -228,6 +228,9 @@ impl TcpConnection {
                     } else {
                         self.process_send(selector)?;
                     }
+                    if !self.closed {
+                        self.update_interests(selector);
+                    }
                 }
                 if !self.closed && ready.is_readable() {
                     self.process_receive(selector)?;


### PR DESCRIPTION
some tcp server can't work with gnirehtet well .

old code work in this way: 

In this situation : 
relay-rust call process() first , and **both ready.is_readable() and ready.is_writable() are true** . 

relay-rust  do process_send() successfully , and then call process_receive()?   ( ? is important ) 
process_receive()?  throw error(would block) to on_ready()  , on_ready() will ignore this err_wouldblock . 
BECAUSE process_receive throw error ,so **self.update_interests(selector) in process()** won't be called . 

Ant the next process() will still be interest with  read and write . 
but the write buff is null ,so the connection is closed .


