### PR TITLE
Whitelist bundle id of apps for reverse tether

### DIFF
--- a/app/src/main/java/com/genymobile/gnirehtet/GnirehtetActivity.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/GnirehtetActivity.java
@@ -23,7 +23,7 @@ public class GnirehtetActivity extends Activity {
 
     public static final String EXTRA_DNS_SERVERS = "dnsServers";
     public static final String EXTRA_ROUTES = "routes";
-    public static final String EXTRA_BUNDLE_ID = "whitelistBundleId";
+    public static final String EXTRA_BUNDLE_IDS = "whitelistBundleIds";
 
     private static final int VPN_REQUEST_CODE = 0;
 
@@ -60,7 +60,7 @@ public class GnirehtetActivity extends Activity {
         if (routes == null) {
             routes = new String[0];
         }
-        String[] whitelistBundleIds = intent.getStringArrayExtra(EXTRA_BUNDLE_ID);
+        String[] whitelistBundleIds = intent.getStringArrayExtra(EXTRA_BUNDLE_IDS);
         if (whitelistBundleIds == null) {
             whitelistBundleIds = new String[0];
         }

--- a/app/src/main/java/com/genymobile/gnirehtet/GnirehtetActivity.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/GnirehtetActivity.java
@@ -23,6 +23,7 @@ public class GnirehtetActivity extends Activity {
 
     public static final String EXTRA_DNS_SERVERS = "dnsServers";
     public static final String EXTRA_ROUTES = "routes";
+    public static final String EXTRA_BUNDLE_ID = "whitelistBundleId";
 
     private static final int VPN_REQUEST_CODE = 0;
 
@@ -59,7 +60,11 @@ public class GnirehtetActivity extends Activity {
         if (routes == null) {
             routes = new String[0];
         }
-        return new VpnConfiguration(Net.toInetAddresses(dnsServers), Net.toCIDRs(routes));
+        String[] whitelistBundleIds = intent.getStringArrayExtra(EXTRA_BUNDLE_ID);
+        if (whitelistBundleIds == null) {
+            whitelistBundleIds = new String[0];
+        }
+        return new VpnConfiguration(Net.toInetAddresses(dnsServers), Net.toCIDRs(routes), whitelistBundleIds);
     }
 
     private boolean startGnirehtet(VpnConfiguration config) {

--- a/app/src/main/java/com/genymobile/gnirehtet/GnirehtetService.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/GnirehtetService.java
@@ -18,6 +18,7 @@ package com.genymobile.gnirehtet;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.LinkAddress;
 import android.net.LinkProperties;
@@ -132,6 +133,18 @@ public class GnirehtetService extends VpnService {
         } else {
             for (InetAddress dnsServer : dnsServers) {
                 builder.addDnsServer(dnsServer);
+            }
+        }
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            Log.i(TAG, "Setting whitelist bundle id");
+            for (String app : config.getWhitelistBundleIds()) {
+                Log.i(TAG, app + " traffic is being routed through USB");
+                try {
+                    builder.addAllowedApplication(app);
+                } catch (PackageManager.NameNotFoundException e) {
+                    Log.i(TAG, app + " not found");
+                }
             }
         }
 

--- a/app/src/main/java/com/genymobile/gnirehtet/GnirehtetService.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/GnirehtetService.java
@@ -143,7 +143,7 @@ public class GnirehtetService extends VpnService {
                 try {
                     builder.addAllowedApplication(app);
                 } catch (PackageManager.NameNotFoundException e) {
-                    Log.i(TAG, app + " not found");
+                    Log.e(TAG, app + " not found");
                 }
             }
         }

--- a/app/src/main/java/com/genymobile/gnirehtet/VpnConfiguration.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/VpnConfiguration.java
@@ -26,15 +26,17 @@ public class VpnConfiguration implements Parcelable {
 
     private final InetAddress[] dnsServers;
     private final CIDR[] routes;
+    private String[] whitelistBundleIds = new String[0];
 
     public VpnConfiguration() {
         this.dnsServers = new InetAddress[0];
         this.routes = new CIDR[0];
     }
 
-    public VpnConfiguration(InetAddress[] dnsServers, CIDR[] routes) {
+    public VpnConfiguration(InetAddress[] dnsServers, CIDR[] routes, String[] whitelistBundleIds) {
         this.dnsServers = dnsServers;
         this.routes = routes;
+        this.whitelistBundleIds = whitelistBundleIds;
     }
 
     private VpnConfiguration(Parcel source) {
@@ -48,6 +50,7 @@ public class VpnConfiguration implements Parcelable {
             throw new AssertionError("Invalid address", e);
         }
         routes = source.createTypedArray(CIDR.CREATOR);
+        whitelistBundleIds = source.createStringArray();
     }
 
     public InetAddress[] getDnsServers() {
@@ -58,6 +61,10 @@ public class VpnConfiguration implements Parcelable {
         return routes;
     }
 
+    public String[] getWhitelistBundleIds() {
+        return this.whitelistBundleIds;
+    }
+
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(dnsServers.length);
@@ -65,6 +72,7 @@ public class VpnConfiguration implements Parcelable {
             dest.writeByteArray(addr.getAddress());
         }
         dest.writeTypedArray(routes, 0);
+        dest.writeStringArray(whitelistBundleIds);
     }
 
     @Override

--- a/relay-java/src/main/java/com/genymobile/gnirehtet/CommandLineArguments.java
+++ b/relay-java/src/main/java/com/genymobile/gnirehtet/CommandLineArguments.java
@@ -27,6 +27,7 @@ public class CommandLineArguments {
     public static final int PARAM_DNS_SERVER = 1 << 1;
     public static final int PARAM_ROUTES = 1 << 2;
     public static final int PARAM_PORT = 1 << 3;
+    public static final int PARAM_WHITELIST_BUNDLE_IDS = 1 << 4;
 
     public static final int DEFAULT_PORT = 31416;
 
@@ -34,6 +35,7 @@ public class CommandLineArguments {
     private String serial;
     private String dnsServers;
     private String routes;
+    private String whitelistBundleIds;
 
     public static CommandLineArguments parse(int acceptedParameters, String... args) {
         CommandLineArguments arguments = new CommandLineArguments();
@@ -69,6 +71,15 @@ public class CommandLineArguments {
                     throw new IllegalArgumentException("Invalid port: " + arguments.port);
                 }
                 ++i;
+            } else if ((acceptedParameters & PARAM_WHITELIST_BUNDLE_IDS) != 0 && "-b".equals(arg)) {
+                if (arguments.whitelistBundleIds != null) {
+                    throw new IllegalArgumentException("Whitelist bundle ids already set");
+                }
+                if (i == args.length - 1) {
+                throw new IllegalArgumentException("Missing -b parameter");
+                }
+                arguments.whitelistBundleIds = args[i + 1];
+                ++i;
             } else if ((acceptedParameters & PARAM_SERIAL) != 0 && arguments.serial == null) {
                 arguments.serial = arg;
             } else {
@@ -95,5 +106,9 @@ public class CommandLineArguments {
 
     public int getPort() {
         return port;
+    }
+
+    public String getWhitelistBundleIds() {
+        return whitelistBundleIds;
     }
 }

--- a/relay-java/src/main/java/com/genymobile/gnirehtet/Main.java
+++ b/relay-java/src/main/java/com/genymobile/gnirehtet/Main.java
@@ -87,7 +87,7 @@ public final class Main {
             }
         },
         RUN("run", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES
-                | CommandLineArguments.PARAM_PORT) {
+                | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_IDS ) {
             @Override
             String getDescription() {
                 return "Enable reverse tethering for exactly one device:\n"
@@ -102,7 +102,7 @@ public final class Main {
                 cmdRun(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort(), args.getWhitelistBundleIds());
             }
         },
-        AUTORUN("autorun", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_ID) {
+        AUTORUN("autorun", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_IDS) {
             @Override
             String getDescription() {
                 return "Enable reverse tethering for all devices:\n"
@@ -116,7 +116,7 @@ public final class Main {
             }
         },
         START("start", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES
-                | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_ID) {
+                | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_IDS) {
             @Override
             String getDescription() {
                 return "Start a client on the Android device and exit.\n"
@@ -139,7 +139,7 @@ public final class Main {
                 cmdStart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort(), args.getWhitelistBundleIds());
             }
         },
-        AUTOSTART("autostart", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_ID) {
+        AUTOSTART("autostart", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_IDS) {
             @Override
             String getDescription() {
                 return "Listen for device connexions and start a client on every detected\n"
@@ -167,7 +167,7 @@ public final class Main {
             }
         },
         RESTART("restart", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES
-                | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_ID) {
+                | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_IDS) {
             @Override
             String getDescription() {
                 return "Stop then start.";
@@ -412,7 +412,7 @@ public final class Main {
         if ((command.acceptedParameters & CommandLineArguments.PARAM_ROUTES) != 0) {
             builder.append(" [-r ROUTE[,ROUTE2,...]]");
         }
-        if ((command.acceptedParameters & CommandLineArguments.PARAM_WHITELIST_BUNDLE_ID) != 0) {
+        if ((command.acceptedParameters & CommandLineArguments.PARAM_WHITELIST_BUNDLE_IDS) != 0) {
             builder.append(" [-b BUNDLE_ID[,BUNDLE_ID2,...]]");
         }
         builder.append(NL);

--- a/relay-java/src/main/java/com/genymobile/gnirehtet/Main.java
+++ b/relay-java/src/main/java/com/genymobile/gnirehtet/Main.java
@@ -99,10 +99,10 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdRun(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort());
+                cmdRun(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort(), args.getWhitelistBundleIds());
             }
         },
-        AUTORUN("autorun", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT) {
+        AUTORUN("autorun", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_ID) {
             @Override
             String getDescription() {
                 return "Enable reverse tethering for all devices:\n"
@@ -112,11 +112,11 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdAutorun(args.getDnsServers(), args.getRoutes(), args.getPort());
+                cmdAutorun(args.getDnsServers(), args.getRoutes(), args.getPort(), args.getWhitelistBundleIds());
             }
         },
         START("start", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES
-                | CommandLineArguments.PARAM_PORT) {
+                | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_ID) {
             @Override
             String getDescription() {
                 return "Start a client on the Android device and exit.\n"
@@ -126,6 +126,7 @@ public final class Main {
                         + "DNS server(s). Otherwise, use 8.8.8.8 (Google public DNS).\n"
                         + "If -r is given, then only reverse tether the specified routes.\n"
                         + "If -p is given, then make the relay server listen on the specified\n"
+                        + "If -b is given, then reverse tethering will be enabled only for specified application's bundle ids\n"
                         + "port. Otherwise, use port 31416.\n"
                         + "Otherwise, use 0.0.0.0/0 (redirect the whole traffic).\n"
                         + "If the client is already started, then do nothing, and ignore\n"
@@ -135,10 +136,10 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdStart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort());
+                cmdStart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort(), args.getWhitelistBundleIds());
             }
         },
-        AUTOSTART("autostart", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT) {
+        AUTOSTART("autostart", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_ID) {
             @Override
             String getDescription() {
                 return "Listen for device connexions and start a client on every detected\n"
@@ -149,7 +150,7 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdAutostart(args.getDnsServers(), args.getRoutes(), args.getPort());
+                cmdAutostart(args.getDnsServers(), args.getRoutes(), args.getPort(), args.getWhitelistBundleIds());
             }
         },
         STOP("stop", CommandLineArguments.PARAM_SERIAL) {
@@ -166,7 +167,7 @@ public final class Main {
             }
         },
         RESTART("restart", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES
-                | CommandLineArguments.PARAM_PORT) {
+                | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_WHITELIST_BUNDLE_ID) {
             @Override
             String getDescription() {
                 return "Stop then start.";
@@ -174,7 +175,7 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdRestart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort());
+                cmdRestart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort(), args.getWhitelistBundleIds());
             }
         },
         TUNNEL("tunnel", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_PORT) {
@@ -231,9 +232,9 @@ public final class Main {
         cmdInstall(serial);
     }
 
-    private static void cmdRun(String serial, String dnsServers, String routes, int port) throws IOException {
+    private static void cmdRun(String serial, String dnsServers, String routes, int port, String whitelistBundleIds) throws IOException {
         // start in parallel so that the relay server is ready when the client connects
-        asyncStart(serial, dnsServers, routes, port);
+        asyncStart(serial, dnsServers, routes, port, whitelistBundleIds);
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             // executed on Ctrl+C
@@ -247,10 +248,10 @@ public final class Main {
         cmdRelay(port);
     }
 
-    private static void cmdAutorun(final String dnsServers, final String routes, int port) throws IOException {
+    private static void cmdAutorun(final String dnsServers, final String routes, int port, final String whitelistBundleIds) throws IOException {
         new Thread(() -> {
             try {
-                cmdAutostart(dnsServers, routes, port);
+                cmdAutostart(dnsServers, routes, port, whitelistBundleIds);
             } catch (Exception e) {
                 Log.e(TAG, "Cannot auto start clients", e);
             }
@@ -260,7 +261,7 @@ public final class Main {
     }
 
     @SuppressWarnings("checkstyle:MagicNumber")
-    private static void cmdStart(String serial, String dnsServers, String routes, int port) throws InterruptedException, IOException,
+    private static void cmdStart(String serial, String dnsServers, String routes, int port, String whitelistBundleIds) throws InterruptedException, IOException,
             CommandExecutionException {
         if (mustInstallClient(serial)) {
             cmdInstall(serial);
@@ -280,12 +281,15 @@ public final class Main {
         if (routes != null) {
             Collections.addAll(cmd, "--esa", "routes", routes);
         }
+        if (whitelistBundleIds != null) {
+            Collections.addAll(cmd, "--esa", "whitelistBundleIds", whitelistBundleIds);
+        }
         execAdb(serial, cmd);
     }
 
-    private static void cmdAutostart(final String dnsServers, final String routes, int port) {
+    private static void cmdAutostart(final String dnsServers, final String routes, int port, final String whitelistBundleIds) {
         AdbMonitor adbMonitor = new AdbMonitor((serial) -> {
-            asyncStart(serial, dnsServers, routes, port);
+            asyncStart(serial, dnsServers, routes, port, whitelistBundleIds);
         });
         adbMonitor.monitor();
     }
@@ -296,10 +300,10 @@ public final class Main {
                 "com.genymobile.gnirehtet/.GnirehtetActivity");
     }
 
-    private static void cmdRestart(String serial, String dnsServers, String routes, int port) throws InterruptedException, IOException,
+    private static void cmdRestart(String serial, String dnsServers, String routes, int port, String whitelistBundleIds) throws InterruptedException, IOException,
             CommandExecutionException {
         cmdStop(serial);
-        cmdStart(serial, dnsServers, routes, port);
+        cmdStart(serial, dnsServers, routes, port, whitelistBundleIds);
     }
 
     private static void cmdTunnel(String serial, int port) throws InterruptedException, IOException, CommandExecutionException {
@@ -311,10 +315,10 @@ public final class Main {
         new Relay(port).run();
     }
 
-    private static void asyncStart(String serial, String dnsServers, String routes, int port) {
+    private static void asyncStart(String serial, String dnsServers, String routes, int port, String whitelistBundleIds) {
         new Thread(() -> {
             try {
-                cmdStart(serial, dnsServers, routes, port);
+                cmdStart(serial, dnsServers, routes, port, whitelistBundleIds);
             } catch (Exception e) {
                 Log.e(TAG, "Cannot start client", e);
             }
@@ -407,6 +411,9 @@ public final class Main {
         }
         if ((command.acceptedParameters & CommandLineArguments.PARAM_ROUTES) != 0) {
             builder.append(" [-r ROUTE[,ROUTE2,...]]");
+        }
+        if ((command.acceptedParameters & CommandLineArguments.PARAM_WHITELIST_BUNDLE_ID) != 0) {
+            builder.append(" [-b BUNDLE_ID[,BUNDLE_ID2,...]]");
         }
         builder.append(NL);
         String[] descLines = command.getDescription().split("\n");

--- a/relay-rust/src/cli_args.rs
+++ b/relay-rust/src/cli_args.rs
@@ -125,13 +125,14 @@ impl CommandLineArguments {
 mod tests {
     use super::*;
 
-    const ACCEPT_ALL: u8 = PARAM_SERIAL | PARAM_DNS_SERVERS | PARAM_ROUTES;
+    const ACCEPT_ALL: u8 = PARAM_SERIAL | PARAM_DNS_SERVERS | PARAM_ROUTES | PARAM_WHITELIST_BUNDLE_ID;
 
     #[test]
     fn test_no_args() {
         let args = CommandLineArguments::parse(ACCEPT_ALL, Vec::<&str>::new()).unwrap();
         assert!(args.serial.is_none());
         assert!(args.dns_servers.is_none());
+        assert!(args.whitelist_bundle_id.is_none());
     }
 
     #[test]
@@ -193,6 +194,19 @@ mod tests {
     #[test]
     fn test_no_routes_parameter() {
         let raw_args = vec!["-r"];
+        assert!(CommandLineArguments::parse(ACCEPT_ALL, raw_args).is_err());
+    }
+
+    #[test]
+    fn test_bundle_id_parameter() {
+        let raw_args = vec!["-b", "com.myapp.xyz"];
+        let args = CommandLineArguments::parse(ACCEPT_ALL, raw_args).unwrap();
+        assert_eq!("com.myapp.xyz", args.whitelist_bundle_id.unwrap());
+    }
+
+    #[test]
+    fn test_no_bundle_id_parameter() {
+        let raw_args = vec!["-b"];
         assert!(CommandLineArguments::parse(ACCEPT_ALL, raw_args).is_err());
     }
 }

--- a/relay-rust/src/cli_args.rs
+++ b/relay-rust/src/cli_args.rs
@@ -19,7 +19,7 @@ pub const PARAM_SERIAL: u8 = 1;
 pub const PARAM_DNS_SERVERS: u8 = 1 << 1;
 pub const PARAM_ROUTES: u8 = 1 << 2;
 pub const PARAM_PORT: u8 = 1 << 3;
-pub const PARAM_WHITELIST_BUNDLE_ID: u8 = 1 << 4;
+pub const PARAM_WHITELIST_BUNDLE_IDS: u8 = 1 << 4;
 
 pub const DEFAULT_PORT: u16 = 31416;
 

--- a/relay-rust/src/cli_args.rs
+++ b/relay-rust/src/cli_args.rs
@@ -19,6 +19,7 @@ pub const PARAM_SERIAL: u8 = 1;
 pub const PARAM_DNS_SERVERS: u8 = 1 << 1;
 pub const PARAM_ROUTES: u8 = 1 << 2;
 pub const PARAM_PORT: u8 = 1 << 3;
+pub const PARAM_WHITELIST_BUNDLE_ID: u8 = 1 << 4;
 
 pub const DEFAULT_PORT: u16 = 31416;
 
@@ -26,6 +27,7 @@ pub struct CommandLineArguments {
     serial: Option<String>,
     dns_servers: Option<String>,
     routes: Option<String>,
+    whitelist_bundle_id: Option<String>,
     port: u16,
 }
 
@@ -35,6 +37,7 @@ impl CommandLineArguments {
         let mut serial = None;
         let mut dns_servers = None;
         let mut routes = None;
+        let mut whitelist_bundle_id = None;
         let mut port = 0;
 
         let mut iter = args.into_iter();
@@ -70,6 +73,15 @@ impl CommandLineArguments {
                 } else {
                     return Err(String::from("Missing -p parameter"));
                 }
+            } else if (accepted_parameters & PARAM_WHITELIST_BUNDLE_ID) != 0 && "-b" == arg {
+                if whitelist_bundle_id.is_some() {
+                    return Err(String::from("Bundle id already set"));
+                }
+                if let Some(value) = iter.next() {
+                    whitelist_bundle_id = Some(value.into());
+                } else {
+                    return Err(String::from("Missing -b parameter"));
+                }
             } else if (accepted_parameters & PARAM_SERIAL) != 0 && serial.is_none() {
                 serial = Some(arg);
             } else {
@@ -84,6 +96,7 @@ impl CommandLineArguments {
             dns_servers,
             routes,
             port,
+            whitelist_bundle_id
         })
     }
 
@@ -101,6 +114,10 @@ impl CommandLineArguments {
 
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    pub fn whitelist_bundle_id(&self) -> Option<&str> {
+        self.whitelist_bundle_id.as_deref()
     }
 }
 

--- a/relay-rust/src/cli_args.rs
+++ b/relay-rust/src/cli_args.rs
@@ -27,8 +27,8 @@ pub struct CommandLineArguments {
     serial: Option<String>,
     dns_servers: Option<String>,
     routes: Option<String>,
-    whitelist_bundle_id: Option<String>,
     port: u16,
+    whitelist_bundle_ids: Option<String>,
 }
 
 impl CommandLineArguments {
@@ -37,8 +37,8 @@ impl CommandLineArguments {
         let mut serial = None;
         let mut dns_servers = None;
         let mut routes = None;
-        let mut whitelist_bundle_id = None;
         let mut port = 0;
+        let mut whitelist_bundle_ids = None;
 
         let mut iter = args.into_iter();
         while let Some(arg) = iter.next() {
@@ -73,12 +73,12 @@ impl CommandLineArguments {
                 } else {
                     return Err(String::from("Missing -p parameter"));
                 }
-            } else if (accepted_parameters & PARAM_WHITELIST_BUNDLE_ID) != 0 && "-b" == arg {
-                if whitelist_bundle_id.is_some() {
+            } else if (accepted_parameters & PARAM_WHITELIST_BUNDLE_IDS) != 0 && "-b" == arg {
+                if whitelist_bundle_ids.is_some() {
                     return Err(String::from("Bundle id already set"));
                 }
                 if let Some(value) = iter.next() {
-                    whitelist_bundle_id = Some(value.into());
+                    whitelist_bundle_ids = Some(value.into());
                 } else {
                     return Err(String::from("Missing -b parameter"));
                 }
@@ -96,7 +96,7 @@ impl CommandLineArguments {
             dns_servers,
             routes,
             port,
-            whitelist_bundle_id
+            whitelist_bundle_ids
         })
     }
 
@@ -116,8 +116,8 @@ impl CommandLineArguments {
         self.port
     }
 
-    pub fn whitelist_bundle_id(&self) -> Option<&str> {
-        self.whitelist_bundle_id.as_deref()
+    pub fn whitelist_bundle_ids(&self) -> Option<&str> {
+        self.whitelist_bundle_ids.as_deref()
     }
 }
 
@@ -125,14 +125,14 @@ impl CommandLineArguments {
 mod tests {
     use super::*;
 
-    const ACCEPT_ALL: u8 = PARAM_SERIAL | PARAM_DNS_SERVERS | PARAM_ROUTES | PARAM_WHITELIST_BUNDLE_ID;
+    const ACCEPT_ALL: u8 = PARAM_SERIAL | PARAM_DNS_SERVERS | PARAM_ROUTES | PARAM_WHITELIST_BUNDLE_IDS;
 
     #[test]
     fn test_no_args() {
         let args = CommandLineArguments::parse(ACCEPT_ALL, Vec::<&str>::new()).unwrap();
         assert!(args.serial.is_none());
         assert!(args.dns_servers.is_none());
-        assert!(args.whitelist_bundle_id.is_none());
+        assert!(args.whitelist_bundle_ids.is_none());
     }
 
     #[test]
@@ -201,7 +201,7 @@ mod tests {
     fn test_bundle_id_parameter() {
         let raw_args = vec!["-b", "com.myapp.xyz"];
         let args = CommandLineArguments::parse(ACCEPT_ALL, raw_args).unwrap();
-        assert_eq!("com.myapp.xyz", args.whitelist_bundle_id.unwrap());
+        assert_eq!("com.myapp.xyz", args.whitelist_bundle_ids.unwrap());
     }
 
     #[test]

--- a/relay-rust/src/main.rs
+++ b/relay-rust/src/main.rs
@@ -220,7 +220,7 @@ impl Command for StartCommand {
          Otherwise, use 0.0.0.0/0 (redirect the whole traffic).\n\
          If -p is given, then make the relay server listen on the specified\n\
          port. Otherwise, use port 31416.\n\
-         If -b is given, then vpn will run only the given applications\n\
+         If -b is given, then reverse tethering will be enabled only for specified application's bundle ids\n\
          If the client is already started, then do nothing, and ignore\n\
          the other parameters.\n\
          10.0.2.2 is mapped to the host 'localhost'."
@@ -631,6 +631,9 @@ fn append_command_usage(msg: &mut String, command: &dyn Command) {
     }
     if (accepted_parameters & cli_args::PARAM_ROUTES) != 0 {
         msg.push_str(" [-r ROUTE[,ROUTE2,...]]");
+    }
+    if (accepted_parameters & cli_args::PARAM_WHITELIST_BUNDLE_ID) != 0 {
+        msg.push_str(" [-b BUNDLE_ID[,BUNDLE_ID2,...]]")
     }
     msg.push('\n');
     for desc_line in command.description().split('\n') {


### PR DESCRIPTION
Adds a cli argument -b, where the user can pass in the bundle id of the applications they want to use reverse tethering on.