### PR TITLE
Try to support proxy

### DIFF
--- a/app/src/main/java/com/genymobile/gnirehtet/GnirehtetService.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/GnirehtetService.java
@@ -22,6 +22,7 @@ import android.net.ConnectivityManager;
 import android.net.LinkAddress;
 import android.net.LinkProperties;
 import android.net.Network;
+import android.net.ProxyInfo;
 import android.net.VpnService;
 import android.os.Build;
 import android.os.Handler;
@@ -114,6 +115,9 @@ public class GnirehtetService extends VpnService {
         Builder builder = new Builder();
         builder.addAddress(VPN_ADDRESS, 32);
         builder.setSession(getString(R.string.app_name));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            builder.setHttpProxy(ProxyInfo.buildDirectProxy("192.168.1.19", 8899));
+        }
 
         CIDR[] routes = config.getRoutes();
         if (routes.length == 0) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 ext {
-    compileSdkVersion = 28
-    buildToolsVersion = "28.0.3"
+    compileSdkVersion = 29
+    buildToolsVersion = "29.0.3"
 }
 
 buildscript {


### PR DESCRIPTION
This code is nothing more than a draft.

# What it could do
It would redirect your request to a proxy, like whistle I host in port 8899.

I could see my phone's network request in my whistle console, and I could do some redirecting like redirecting foobar.com to localhost, to verify my local changes. (I am also the developer of foobar.com)

It just works fine in my computer.

# What it cannot do
I notice there are some capture errors in CONNECT.
![image](https://github.com/Genymobile/gnirehtet/assets/25839908/f6423bdf-b6fb-4cca-b688-fe4649b2cf66)

I have no idea what it is. So I am not sure my changes could be accepted.

This is just a draft, if it is accepted, I will add some Android UX to config the proxy address and port.