### PR TITLE
feat: add HTTP proxy with exclusion list support (API 29+)

### DIFF
--- a/app/src/main/java/com/genymobile/gnirehtet/GnirehtetActivity.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/GnirehtetActivity.java
@@ -23,6 +23,9 @@ public class GnirehtetActivity extends Activity {
 
     public static final String EXTRA_DNS_SERVERS = "dnsServers";
     public static final String EXTRA_ROUTES = "routes";
+    public static final String EXTRA_PROXY_HOST = "proxyHost";
+    public static final String EXTRA_PROXY_PORT = "proxyPort";
+    public static final String EXTRA_EXCLUSION_LIST = "exclusionList";
 
     private static final int VPN_REQUEST_CODE = 0;
 
@@ -59,7 +62,13 @@ public class GnirehtetActivity extends Activity {
         if (routes == null) {
             routes = new String[0];
         }
-        return new VpnConfiguration(Net.toInetAddresses(dnsServers), Net.toCIDRs(routes));
+        String proxyHost = intent.getStringExtra(EXTRA_PROXY_HOST);
+        int proxyPort = intent.getIntExtra(EXTRA_PROXY_PORT, -1);
+        String[] exclusionList = intent.getStringArrayExtra(EXTRA_EXCLUSION_LIST);
+        if (exclusionList == null) {
+            exclusionList = new String[0];
+        }
+        return new VpnConfiguration(Net.toInetAddresses(dnsServers), Net.toCIDRs(routes), proxyHost, proxyPort, exclusionList);
     }
 
     private boolean startGnirehtet(VpnConfiguration config) {

--- a/app/src/main/java/com/genymobile/gnirehtet/GnirehtetService.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/GnirehtetService.java
@@ -22,6 +22,7 @@ import android.net.ConnectivityManager;
 import android.net.LinkAddress;
 import android.net.LinkProperties;
 import android.net.Network;
+import android.net.ProxyInfo;
 import android.net.VpnService;
 import android.os.Build;
 import android.os.Handler;
@@ -139,6 +140,16 @@ public class GnirehtetService extends VpnService {
         // so switch to synchronous I/O to avoid polling
         builder.setBlocking(true);
         builder.setMtu(MTU);
+
+        // Set HTTP proxy with exclusion list if configured (API 29+)
+        if (config.hasProxy() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            String proxyHost = config.getProxyHost();
+            int proxyPort = config.getProxyPort();
+            String[] exclusionList = config.getExclusionList();
+            ProxyInfo proxyInfo = ProxyInfo.buildDirectProxy(proxyHost, proxyPort, exclusionList);
+            builder.setHttpProxy(proxyInfo);
+            Log.d(TAG, "HTTP proxy configured: " + proxyHost + ":" + proxyPort + " with " + exclusionList.length + " exclusions");
+        }
 
         vpnInterface = builder.establish();
         if (vpnInterface == null) {

--- a/app/src/main/java/com/genymobile/gnirehtet/VpnConfiguration.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/VpnConfiguration.java
@@ -26,15 +26,28 @@ public class VpnConfiguration implements Parcelable {
 
     private final InetAddress[] dnsServers;
     private final CIDR[] routes;
+    private final String proxyHost;
+    private final int proxyPort;
+    private final String[] exclusionList;
 
     public VpnConfiguration() {
         this.dnsServers = new InetAddress[0];
         this.routes = new CIDR[0];
+        this.proxyHost = null;
+        this.proxyPort = -1;
+        this.exclusionList = new String[0];
     }
 
     public VpnConfiguration(InetAddress[] dnsServers, CIDR[] routes) {
+        this(dnsServers, routes, null, -1, new String[0]);
+    }
+
+    public VpnConfiguration(InetAddress[] dnsServers, CIDR[] routes, String proxyHost, int proxyPort, String[] exclusionList) {
         this.dnsServers = dnsServers;
         this.routes = routes;
+        this.proxyHost = proxyHost;
+        this.proxyPort = proxyPort;
+        this.exclusionList = exclusionList;
     }
 
     private VpnConfiguration(Parcel source) {
@@ -48,6 +61,9 @@ public class VpnConfiguration implements Parcelable {
             throw new AssertionError("Invalid address", e);
         }
         routes = source.createTypedArray(CIDR.CREATOR);
+        proxyHost = source.readString();
+        proxyPort = source.readInt();
+        exclusionList = source.createStringArray();
     }
 
     public InetAddress[] getDnsServers() {
@@ -58,6 +74,22 @@ public class VpnConfiguration implements Parcelable {
         return routes;
     }
 
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    public int getProxyPort() {
+        return proxyPort;
+    }
+
+    public String[] getExclusionList() {
+        return exclusionList;
+    }
+
+    public boolean hasProxy() {
+        return proxyHost != null && proxyPort > 0;
+    }
+
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(dnsServers.length);
@@ -65,6 +97,9 @@ public class VpnConfiguration implements Parcelable {
             dest.writeByteArray(addr.getAddress());
         }
         dest.writeTypedArray(routes, 0);
+        dest.writeString(proxyHost);
+        dest.writeInt(proxyPort);
+        dest.writeStringArray(exclusionList);
     }
 
     @Override


### PR DESCRIPTION
## Summary

This PR adds support for HTTP proxy with exclusion list, allowing users to exclude certain domains from being proxied through the VPN.

## Changes

1. **VpnConfiguration.java**: Added `proxyHost`, `proxyPort`, and `exclusionList` fields with Parcelable support

2. **GnirehtetActivity.java**: Added new intent extras:
   - `EXTRA_PROXY_HOST`: Proxy hostname
   - `EXTRA_PROXY_PORT`: Proxy port
   - `EXTRA_EXCLUSION_LIST`: Array of domains to exclude

3. **GnirehtetService.java**: Added `setHttpProxy()` call when proxy is configured (API 29+)

## Usage

To use the exclusion list feature, pass the following parameters when starting gnirehtet:

```
adb shell am start-foreground-service -a com.genymobile.gnirehtet.START \
    --ei proxyPort 8080 \
    --es proxyHost "192.168.1.1" \
    --esa exclusionList "example.com,google.com"
```

The excluded domains will bypass the proxy and connect directly.

## Bounty

This implements the feature requested in issue #482 - 50 USD Bounty for gnirehtet android app for http proxy exclusion bypass feature