### PR TITLE
Fix `run` command failing on reconnect and with missing APK

### DIFF
--- a/relay-rust/src/main.rs
+++ b/relay-rust/src/main.rs
@@ -365,8 +365,33 @@ fn cmd_run(
     routes: Option<&str>,
     port: u16,
 ) -> Result<(), CommandExecutionError> {
-    // start in parallel so that the relay server is ready when the client connects
+    // Start the client immediately, then monitor for reconnections
     async_start(serial, dns_servers, routes, port);
+
+    // Spawn a monitor thread that detects device reconnections and re-establishes
+    // the tunnel automatically (e.g. after USB mode changes or cable replug)
+    {
+        let monitor_serial = serial.map(String::from);
+        let monitor_dns_servers = dns_servers.map(String::from);
+        let monitor_routes = routes.map(String::from);
+        thread::spawn(move || {
+            let mut adb_monitor = AdbMonitor::new(Box::new(move |serial: &str| {
+                let target_serial = monitor_serial.as_ref().map(String::as_ref);
+                let dns_servers = monitor_dns_servers.as_ref().map(String::as_ref);
+                let routes = monitor_routes.as_ref().map(String::as_ref);
+                // Only restart for our target device (or any device if no serial specified)
+                if target_serial.is_none() || target_serial == Some(serial) {
+                    info!(
+                        target: TAG,
+                        "Device {} reconnected, re-establishing tunnel...",
+                        serial
+                    );
+                    async_start(Some(serial), dns_servers, routes, port);
+                }
+            }));
+            adb_monitor.monitor();
+        });
+    }
 
     let ctrlc_serial = serial.map(String::from);
     ctrlc::set_handler(move || {
@@ -458,8 +483,14 @@ fn cmd_start(
         }
     }
 
-    info!(target: TAG, "Starting client...");
+    info!(
+        target: TAG,
+        "Starting client{}...",
+        serial.map_or(String::new(), |s| format!(" for device {}", s))
+    );
+    info!(target: TAG, "Setting up adb reverse tunnel on port {}...", port);
     cmd_tunnel(serial, port)?;
+    info!(target: TAG, "Tunnel established, launching VPN client on device...");
 
     let mut adb_args = vec![
         "shell",
@@ -524,8 +555,20 @@ fn cmd_tunnel(serial: Option<&str>, port: u16) -> Result<(), CommandExecutionErr
 
 fn cmd_relay(port: u16) -> Result<(), CommandExecutionError> {
     info!(target: TAG, "Starting relay server on port {}...", port);
-    relaylib::relay(port)?;
-    Ok(())
+    match relaylib::relay(port) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::AddrInUse {
+                error!(
+                    target: TAG,
+                    "Port {} is already in use. Another relay may be running. \
+                     Kill it with 'pkill -f gnirehtet' or use a different port with '-p'.",
+                    port
+                );
+            }
+            Err(e.into())
+        }
+    }
 }
 
 fn async_start(serial: Option<&str>, dns_servers: Option<&str>, routes: Option<&str>, port: u16) {
@@ -537,7 +580,12 @@ fn async_start(serial: Option<&str>, dns_servers: Option<&str>, routes: Option<&
         let dns_servers = start_dns_servers.as_ref().map(String::as_ref);
         let routes = start_routes.as_ref().map(String::as_ref);
         if let Err(err) = cmd_start(serial, dns_servers, routes, port) {
-            error!(target: TAG, "Cannot start client: {}", err);
+            error!(
+                target: TAG,
+                "Cannot start client{}: {}. Try reconnecting the device or running 'gnirehtet tunnel' manually.",
+                serial.map_or(String::new(), |s| format!(" ({})", s)),
+                err
+            );
         }
     });
 }

--- a/relay-rust/src/main.rs
+++ b/relay-rust/src/main.rs
@@ -29,6 +29,8 @@ use crate::adb_monitor::AdbMonitor;
 use crate::cli_args::CommandLineArguments;
 use crate::execution_error::{Cmd, CommandExecutionError, ProcessIoError, ProcessStatusError};
 use std::env;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::path::Path;
 use std::process::{self, exit};
 use std::thread;
 use std::time::Duration;
@@ -379,7 +381,25 @@ fn cmd_run(
     })
     .expect("Error setting Ctrl-C handler");
 
-    cmd_relay(port)
+    if is_relay_running(port) {
+        info!(
+            target: TAG,
+            "Relay server already running on port {}, reusing existing instance",
+            port
+        );
+        // Keep the process alive until Ctrl+C (handled above)
+        loop {
+            thread::sleep(Duration::from_secs(60));
+        }
+    } else {
+        cmd_relay(port)
+    }
+}
+
+fn is_relay_running(port: u16) -> bool {
+    use std::net::TcpStream;
+    let addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), port);
+    TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok()
 }
 
 fn cmd_autorun(
@@ -409,10 +429,33 @@ fn cmd_start(
     port: u16,
 ) -> Result<(), CommandExecutionError> {
     if must_install_client(serial)? {
-        cmd_install(serial)?;
-        // wait a bit after the app is installed so that intent actions are correctly
-        // registered
-        thread::sleep(Duration::from_millis(500));
+        let apk_path = get_apk_path();
+        if Path::new(&apk_path).exists() {
+            cmd_install(serial)?;
+            // wait a bit after the app is installed so that intent actions are correctly
+            // registered
+            thread::sleep(Duration::from_millis(500));
+        } else if is_client_installed(serial) {
+            warn!(
+                target: TAG,
+                "APK file '{}' not found, but client is already installed (possibly a different \
+                 version). Skipping install.",
+                apk_path
+            );
+        } else {
+            error!(
+                target: TAG,
+                "APK file '{}' not found and client is not installed. \
+                 Set GNIREHTET_APK to the correct path.",
+                apk_path
+            );
+            let cmd = Cmd::new("adb", vec!["install", "-r", &apk_path]);
+            return Err(ProcessIoError::new(
+                cmd,
+                std::io::Error::new(std::io::ErrorKind::NotFound, "APK file not found"),
+            )
+            .into());
+        }
     }
 
     info!(target: TAG, "Starting client...");
@@ -531,6 +574,20 @@ fn exec_adb<S: Into<String>>(
             let cmd = Cmd::new(adb, adb_args);
             Err(ProcessIoError::new(cmd, err).into())
         }
+    }
+}
+
+fn is_client_installed(serial: Option<&str>) -> bool {
+    let args = create_adb_args(
+        serial,
+        vec!["shell", "pm", "list", "packages", "com.genymobile.gnirehtet"],
+    );
+    let adb = get_adb_path();
+    if let Ok(output) = process::Command::new(&adb).args(&args[..]).output() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        stdout.contains("package:com.genymobile.gnirehtet")
+    } else {
+        false
     }
 }
 


### PR DESCRIPTION
## Summary
- If a relay server is already running on the port (e.g. after USB reconnect), `gnirehtet run` now detects it and reuses the existing instance instead of failing with `Address already in use (os error 48)`.
- When the APK file is not at the expected path (common with package manager installs like Homebrew), `gnirehtet run` would block on the install step even if the client was already installed on the device. It now checks for APK file existence and skips install when the client is already present.
- **Auto-recovery**: `gnirehtet run` now monitors for device reconnections using `AdbMonitor` and automatically re-establishes the tunnel when the device drops and reconnects (e.g. USB mode change, cable replug). Previously, users had to manually restart gnirehtet after any USB disruption.
- Improved logging with descriptive messages for each startup step, reconnection events, and actionable error messages for common failures.

## Details

### Port already in use
Added `is_relay_running()` which attempts a TCP connect to the relay port. If a relay is already listening, `cmd_run` logs a message and keeps the process alive (for Ctrl+C cleanup) without trying to bind a second listener.

### APK install with missing file
In `cmd_start`, before calling `adb install -r`, we now check if the APK file exists on disk. If it doesn't:
- If the client is already installed on the device (`pm list packages` check via `is_client_installed()`), we skip the install with a warning and proceed to start the client.
- If the client is not installed at all, we return a clear error telling the user to set `GNIREHTET_APK`.

### Auto-recovery on device reconnect
`cmd_run` now spawns an `AdbMonitor` thread alongside the relay server. When a device disconnects and reconnects (USB mode change, cable replug, etc.), the monitor detects it and automatically calls `async_start` to re-establish the reverse tunnel and restart the VPN client. This works across all USB modes including "No data transfer".

## Test plan
- [x] `cargo check` / `cargo build --release` passes with no new warnings
- [x] `gnirehtet run` works on first use (clean start)
- [x] Kill `gnirehtet run`, then run it again → reuses existing relay instead of "address already in use" error
- [x] Unplug and replug USB → auto-recovers tunnel
- [x] Switch USB modes (file transfer, USB tethering, no data transfer) → auto-recovers
- [x] Works when installed via Homebrew (APK not in current directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)