### PR TITLE
Add HTTP proxy exclusion list support (Feature #482)

### DIFF
--- a/app/src/main/java/com/genymobile/gnirehtet/GnirehtetActivity.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/GnirehtetActivity.java
@@ -23,6 +23,7 @@ public class GnirehtetActivity extends Activity {
 
     public static final String EXTRA_DNS_SERVERS = "dnsServers";
     public static final String EXTRA_ROUTES = "routes";
+    public static final String EXTRA_PROXY_EXCLUSION_LIST = "proxyExclusionList";
 
     private static final int VPN_REQUEST_CODE = 0;
 
@@ -59,7 +60,11 @@ public class GnirehtetActivity extends Activity {
         if (routes == null) {
             routes = new String[0];
         }
-        return new VpnConfiguration(Net.toInetAddresses(dnsServers), Net.toCIDRs(routes));
+        String[] proxyExclusionList = intent.getStringArrayExtra(EXTRA_PROXY_EXCLUSION_LIST);
+        if (proxyExclusionList == null) {
+            proxyExclusionList = new String[0];
+        }
+        return new VpnConfiguration(Net.toInetAddresses(dnsServers), Net.toCIDRs(routes), proxyExclusionList);
     }
 
     private boolean startGnirehtet(VpnConfiguration config) {

--- a/app/src/main/java/com/genymobile/gnirehtet/GnirehtetService.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/GnirehtetService.java
@@ -22,6 +22,7 @@ import android.net.ConnectivityManager;
 import android.net.LinkAddress;
 import android.net.LinkProperties;
 import android.net.Network;
+import android.net.ProxyInfo;
 import android.net.VpnService;
 import android.os.Build;
 import android.os.Handler;
@@ -135,6 +136,9 @@ public class GnirehtetService extends VpnService {
             }
         }
 
+        // Set up HTTP proxy with exclusion list
+        setupHttpProxy(builder, config);
+
         // non-blocking by default, but FileChannel is not selectable, that's stupid!
         // so switch to synchronous I/O to avoid polling
         builder.setBlocking(true);
@@ -149,6 +153,30 @@ public class GnirehtetService extends VpnService {
 
         setAsUndernlyingNetwork();
         return true;
+    }
+
+    @SuppressWarnings("checkstyle:MagicNumber")
+    private void setupHttpProxy(Builder builder, VpnConfiguration config) {
+        String[] exclusionList = config.getProxyExclusionList();
+        if (exclusionList == null || exclusionList.length == 0) {
+            return;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // Convert exclusion list to comma-separated string
+            StringBuilder exclusionListStr = new StringBuilder();
+            for (int i = 0; i < exclusionList.length; i++) {
+                if (i > 0) {
+                    exclusionListStr.append(",");
+                }
+                exclusionListStr.append(exclusionList[i]);
+            }
+            ProxyInfo proxyInfo = ProxyInfo.buildDirectProxy(VPN_ADDRESS.getHostAddress(), 31416, exclusionList);
+            builder.setHttpProxy(proxyInfo);
+            Log.d(TAG, "HTTP proxy configured with exclusion list: " + exclusionListStr.toString());
+        } else {
+            Log.w(TAG, "HTTP proxy exclusion list requires Android 10 (API 29) or higher");
+        }
     }
 
     @SuppressWarnings("checkstyle:MagicNumber")

--- a/app/src/main/java/com/genymobile/gnirehtet/VpnConfiguration.java
+++ b/app/src/main/java/com/genymobile/gnirehtet/VpnConfiguration.java
@@ -26,15 +26,24 @@ public class VpnConfiguration implements Parcelable {
 
     private final InetAddress[] dnsServers;
     private final CIDR[] routes;
+    private final String[] proxyExclusionList;
 
     public VpnConfiguration() {
         this.dnsServers = new InetAddress[0];
         this.routes = new CIDR[0];
+        this.proxyExclusionList = new String[0];
     }
 
     public VpnConfiguration(InetAddress[] dnsServers, CIDR[] routes) {
         this.dnsServers = dnsServers;
         this.routes = routes;
+        this.proxyExclusionList = new String[0];
+    }
+
+    public VpnConfiguration(InetAddress[] dnsServers, CIDR[] routes, String[] proxyExclusionList) {
+        this.dnsServers = dnsServers;
+        this.routes = routes;
+        this.proxyExclusionList = proxyExclusionList != null ? proxyExclusionList : new String[0];
     }
 
     private VpnConfiguration(Parcel source) {
@@ -48,6 +57,10 @@ public class VpnConfiguration implements Parcelable {
             throw new AssertionError("Invalid address", e);
         }
         routes = source.createTypedArray(CIDR.CREATOR);
+        proxyExclusionList = source.createStringArray();
+        if (proxyExclusionList == null) {
+            proxyExclusionList = new String[0];
+        }
     }
 
     public InetAddress[] getDnsServers() {
@@ -58,6 +71,10 @@ public class VpnConfiguration implements Parcelable {
         return routes;
     }
 
+    public String[] getProxyExclusionList() {
+        return proxyExclusionList;
+    }
+
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(dnsServers.length);
@@ -65,6 +82,7 @@ public class VpnConfiguration implements Parcelable {
             dest.writeByteArray(addr.getAddress());
         }
         dest.writeTypedArray(routes, 0);
+        dest.writeStringArray(proxyExclusionList);
     }
 
     @Override

--- a/relay-java/src/main/java/com/genymobile/gnirehtet/CommandLineArguments.java
+++ b/relay-java/src/main/java/com/genymobile/gnirehtet/CommandLineArguments.java
@@ -27,6 +27,7 @@ public class CommandLineArguments {
     public static final int PARAM_DNS_SERVER = 1 << 1;
     public static final int PARAM_ROUTES = 1 << 2;
     public static final int PARAM_PORT = 1 << 3;
+    public static final int PARAM_PROXY_EXCLUSION_LIST = 1 << 4;
 
     public static final int DEFAULT_PORT = 31416;
 
@@ -34,6 +35,7 @@ public class CommandLineArguments {
     private String serial;
     private String dnsServers;
     private String routes;
+    private String proxyExclusionList;
 
     public static CommandLineArguments parse(int acceptedParameters, String... args) {
         CommandLineArguments arguments = new CommandLineArguments();
@@ -69,6 +71,15 @@ public class CommandLineArguments {
                     throw new IllegalArgumentException("Invalid port: " + arguments.port);
                 }
                 ++i;
+            } else if ((acceptedParameters & PARAM_PROXY_EXCLUSION_LIST) != 0 && "-x".equals(arg)) {
+                if (arguments.proxyExclusionList != null) {
+                    throw new IllegalArgumentException("Proxy exclusion list already set");
+                }
+                if (i == args.length - 1) {
+                    throw new IllegalArgumentException("Missing -x parameter");
+                }
+                arguments.proxyExclusionList = args[i + 1];
+                ++i; // consume the -x parameter
             } else if ((acceptedParameters & PARAM_SERIAL) != 0 && arguments.serial == null) {
                 arguments.serial = arg;
             } else {
@@ -95,5 +106,9 @@ public class CommandLineArguments {
 
     public int getPort() {
         return port;
+    }
+
+    public String getProxyExclusionList() {
+        return proxyExclusionList;
     }
 }

--- a/relay-java/src/main/java/com/genymobile/gnirehtet/Main.java
+++ b/relay-java/src/main/java/com/genymobile/gnirehtet/Main.java
@@ -87,7 +87,7 @@ public final class Main {
             }
         },
         RUN("run", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES
-                | CommandLineArguments.PARAM_PORT) {
+                | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_PROXY_EXCLUSION_LIST) {
             @Override
             String getDescription() {
                 return "Enable reverse tethering for exactly one device:\n"
@@ -99,10 +99,11 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdRun(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort());
+                cmdRun(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort(), args.getProxyExclusionList());
             }
         },
-        AUTORUN("autorun", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT) {
+        AUTORUN("autorun", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT
+                | CommandLineArguments.PARAM_PROXY_EXCLUSION_LIST) {
             @Override
             String getDescription() {
                 return "Enable reverse tethering for all devices:\n"
@@ -112,11 +113,11 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdAutorun(args.getDnsServers(), args.getRoutes(), args.getPort());
+                cmdAutorun(args.getDnsServers(), args.getRoutes(), args.getPort(), args.getProxyExclusionList());
             }
         },
         START("start", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES
-                | CommandLineArguments.PARAM_PORT) {
+                | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_PROXY_EXCLUSION_LIST) {
             @Override
             String getDescription() {
                 return "Start a client on the Android device and exit.\n"
@@ -127,6 +128,7 @@ public final class Main {
                         + "If -r is given, then only reverse tether the specified routes.\n"
                         + "If -p is given, then make the relay server listen on the specified\n"
                         + "port. Otherwise, use port 31416.\n"
+                        + "If -x is given, then exclude the specified domains from being proxied.\n"
                         + "Otherwise, use 0.0.0.0/0 (redirect the whole traffic).\n"
                         + "If the client is already started, then do nothing, and ignore\n"
                         + "the other parameters.\n"
@@ -135,10 +137,11 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdStart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort());
+                cmdStart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort(), args.getProxyExclusionList());
             }
         },
-        AUTOSTART("autostart", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT) {
+        AUTOSTART("autostart", CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES | CommandLineArguments.PARAM_PORT
+                | CommandLineArguments.PARAM_PROXY_EXCLUSION_LIST) {
             @Override
             String getDescription() {
                 return "Listen for device connexions and start a client on every detected\n"
@@ -149,7 +152,7 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdAutostart(args.getDnsServers(), args.getRoutes(), args.getPort());
+                cmdAutostart(args.getDnsServers(), args.getRoutes(), args.getPort(), args.getProxyExclusionList());
             }
         },
         STOP("stop", CommandLineArguments.PARAM_SERIAL) {
@@ -166,7 +169,7 @@ public final class Main {
             }
         },
         RESTART("restart", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_DNS_SERVER | CommandLineArguments.PARAM_ROUTES
-                | CommandLineArguments.PARAM_PORT) {
+                | CommandLineArguments.PARAM_PORT | CommandLineArguments.PARAM_PROXY_EXCLUSION_LIST) {
             @Override
             String getDescription() {
                 return "Stop then start.";
@@ -174,7 +177,7 @@ public final class Main {
 
             @Override
             void execute(CommandLineArguments args) throws Exception {
-                cmdRestart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort());
+                cmdRestart(args.getSerial(), args.getDnsServers(), args.getRoutes(), args.getPort(), args.getProxyExclusionList());
             }
         },
         TUNNEL("tunnel", CommandLineArguments.PARAM_SERIAL | CommandLineArguments.PARAM_PORT) {
@@ -231,9 +234,9 @@ public final class Main {
         cmdInstall(serial);
     }
 
-    private static void cmdRun(String serial, String dnsServers, String routes, int port) throws IOException {
+    private static void cmdRun(String serial, String dnsServers, String routes, int port, String proxyExclusionList) throws IOException {
         // start in parallel so that the relay server is ready when the client connects
-        asyncStart(serial, dnsServers, routes, port);
+        asyncStart(serial, dnsServers, routes, port, proxyExclusionList);
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             // executed on Ctrl+C
@@ -247,10 +250,10 @@ public final class Main {
         cmdRelay(port);
     }
 
-    private static void cmdAutorun(final String dnsServers, final String routes, int port) throws IOException {
+    private static void cmdAutorun(final String dnsServers, final String routes, int port, final String proxyExclusionList) throws IOException {
         new Thread(() -> {
             try {
-                cmdAutostart(dnsServers, routes, port);
+                cmdAutostart(dnsServers, routes, port, proxyExclusionList);
             } catch (Exception e) {
                 Log.e(TAG, "Cannot auto start clients", e);
             }
@@ -260,7 +263,7 @@ public final class Main {
     }
 
     @SuppressWarnings("checkstyle:MagicNumber")
-    private static void cmdStart(String serial, String dnsServers, String routes, int port) throws InterruptedException, IOException,
+    private static void cmdStart(String serial, String dnsServers, String routes, int port, String proxyExclusionList) throws InterruptedException, IOException,
             CommandExecutionException {
         if (mustInstallClient(serial)) {
             cmdInstall(serial);
@@ -280,12 +283,15 @@ public final class Main {
         if (routes != null) {
             Collections.addAll(cmd, "--esa", "routes", routes);
         }
+        if (proxyExclusionList != null) {
+            Collections.addAll(cmd, "--esa", "proxyExclusionList", proxyExclusionList);
+        }
         execAdb(serial, cmd);
     }
 
-    private static void cmdAutostart(final String dnsServers, final String routes, int port) {
+    private static void cmdAutostart(final String dnsServers, final String routes, int port, final String proxyExclusionList) {
         AdbMonitor adbMonitor = new AdbMonitor((serial) -> {
-            asyncStart(serial, dnsServers, routes, port);
+            asyncStart(serial, dnsServers, routes, port, proxyExclusionList);
         });
         adbMonitor.monitor();
     }
@@ -296,10 +302,10 @@ public final class Main {
                 "com.genymobile.gnirehtet/.GnirehtetActivity");
     }
 
-    private static void cmdRestart(String serial, String dnsServers, String routes, int port) throws InterruptedException, IOException,
+    private static void cmdRestart(String serial, String dnsServers, String routes, int port, String proxyExclusionList) throws InterruptedException, IOException,
             CommandExecutionException {
         cmdStop(serial);
-        cmdStart(serial, dnsServers, routes, port);
+        cmdStart(serial, dnsServers, routes, port, proxyExclusionList);
     }
 
     private static void cmdTunnel(String serial, int port) throws InterruptedException, IOException, CommandExecutionException {
@@ -311,10 +317,10 @@ public final class Main {
         new Relay(port).run();
     }
 
-    private static void asyncStart(String serial, String dnsServers, String routes, int port) {
+    private static void asyncStart(String serial, String dnsServers, String routes, int port, String proxyExclusionList) {
         new Thread(() -> {
             try {
-                cmdStart(serial, dnsServers, routes, port);
+                cmdStart(serial, dnsServers, routes, port, proxyExclusionList);
             } catch (Exception e) {
                 Log.e(TAG, "Cannot start client", e);
             }
@@ -411,6 +417,9 @@ public final class Main {
         }
         if ((command.acceptedParameters & CommandLineArguments.PARAM_ROUTES) != 0) {
             builder.append(" [-r ROUTE[,ROUTE2,...]]");
+        }
+        if ((command.acceptedParameters & CommandLineArguments.PARAM_PROXY_EXCLUSION_LIST) != 0) {
+            builder.append(" [-x EXCLUDE[,EXCLUDE2,...]]");
         }
         builder.append(NL);
         String[] descLines = command.getDescription().split("\n");

--- a/relay-rust/src/cli_args.rs
+++ b/relay-rust/src/cli_args.rs
@@ -19,6 +19,8 @@ pub const PARAM_SERIAL: u8 = 1;
 pub const PARAM_DNS_SERVERS: u8 = 1 << 1;
 pub const PARAM_ROUTES: u8 = 1 << 2;
 pub const PARAM_PORT: u8 = 1 << 3;
+pub const PARAM_PROXY: u8 = 1 << 4;
+pub const PARAM_EXCLUSION_LIST: u8 = 1 << 5;
 
 pub const DEFAULT_PORT: u16 = 31416;
 
@@ -27,6 +29,9 @@ pub struct CommandLineArguments {
     dns_servers: Option<String>,
     routes: Option<String>,
     port: u16,
+    proxy_host: Option<String>,
+    proxy_port: Option<u16>,
+    exclusion_list: Option<String>,
 }
 
 impl CommandLineArguments {
@@ -36,6 +41,9 @@ impl CommandLineArguments {
         let mut dns_servers = None;
         let mut routes = None;
         let mut port = 0;
+        let mut proxy_host = None;
+        let mut proxy_port = None;
+        let mut exclusion_list = None;
 
         let mut iter = args.into_iter();
         while let Some(arg) = iter.next() {
@@ -70,6 +78,34 @@ impl CommandLineArguments {
                 } else {
                     return Err(String::from("Missing -p parameter"));
                 }
+            } else if (accepted_parameters & PARAM_PROXY) != 0 && "-x" == arg {
+                if proxy_host.is_some() {
+                    return Err(String::from("Proxy already set"));
+                }
+                if let Some(value) = iter.next() {
+                    let proxy_value: String = value.into();
+                    if let Some(colon_pos) = proxy_value.rfind(':') {
+                        if colon_pos > 0 && colon_pos < proxy_value.len() - 1 {
+                            proxy_host = Some(proxy_value[..colon_pos].to_string());
+                            proxy_port = Some(proxy_value[colon_pos + 1..].parse().map_err(|_| "Invalid proxy port")?);
+                        } else {
+                            return Err(String::from("Invalid proxy format. Use host:port"));
+                        }
+                    } else {
+                        return Err(String::from("Invalid proxy format. Use host:port"));
+                    }
+                } else {
+                    return Err(String::from("Missing -x parameter"));
+                }
+            } else if (accepted_parameters & PARAM_EXCLUSION_LIST) != 0 && "-e" == arg {
+                if exclusion_list.is_some() {
+                    return Err(String::from("Exclusion list already set"));
+                }
+                if let Some(value) = iter.next() {
+                    exclusion_list = Some(value.into());
+                } else {
+                    return Err(String::from("Missing -e parameter"));
+                }
             } else if (accepted_parameters & PARAM_SERIAL) != 0 && serial.is_none() {
                 serial = Some(arg);
             } else {
@@ -84,6 +120,9 @@ impl CommandLineArguments {
             dns_servers,
             routes,
             port,
+            proxy_host,
+            proxy_port,
+            exclusion_list,
         })
     }
 
@@ -101,6 +140,29 @@ impl CommandLineArguments {
 
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    pub fn proxy_host(&self) -> Option<&str> {
+        self.proxy_host.as_deref()
+    }
+
+    pub fn proxy_port(&self) -> Option<u16> {
+        self.proxy_port
+    }
+
+    pub fn has_proxy(&self) -> bool {
+        self.proxy_host.is_some() && self.proxy_port.is_some()
+    }
+
+    pub fn exclusion_list(&self) -> Option<&str> {
+        self.exclusion_list.as_deref()
+    }
+
+    pub fn exclusion_list_array(&self) -> Vec<String> {
+        match &self.exclusion_list {
+            Some(list) => list.split(',').map(|s| s.to_string()).collect(),
+            None => Vec::new(),
+        }
     }
 }
 

--- a/relay-rust/src/main.rs
+++ b/relay-rust/src/main.rs
@@ -155,6 +155,7 @@ impl Command for RunCommand {
             | cli_args::PARAM_DNS_SERVERS
             | cli_args::PARAM_ROUTES
             | cli_args::PARAM_PORT
+            | cli_args::PARAM_EXCLUSION_LIST
     }
 
     fn description(&self) -> &'static str {
@@ -171,6 +172,7 @@ impl Command for RunCommand {
             args.dns_servers(),
             args.routes(),
             args.port(),
+            args.exclusion_list(),
         )
     }
 }
@@ -182,6 +184,7 @@ impl Command for AutorunCommand {
 
     fn accepted_parameters(&self) -> u8 {
         cli_args::PARAM_DNS_SERVERS | cli_args::PARAM_ROUTES | cli_args::PARAM_PORT
+            | cli_args::PARAM_EXCLUSION_LIST
     }
 
     fn description(&self) -> &'static str {
@@ -191,7 +194,7 @@ impl Command for AutorunCommand {
     }
 
     fn execute(&self, args: &CommandLineArguments) -> Result<(), CommandExecutionError> {
-        cmd_autorun(args.dns_servers(), args.routes(), args.port())
+        cmd_autorun(args.dns_servers(), args.routes(), args.port(), args.exclusion_list())
     }
 }
 
@@ -205,6 +208,7 @@ impl Command for StartCommand {
             | cli_args::PARAM_DNS_SERVERS
             | cli_args::PARAM_ROUTES
             | cli_args::PARAM_PORT
+            | cli_args::PARAM_EXCLUSION_LIST
     }
 
     fn description(&self) -> &'static str {
@@ -217,6 +221,7 @@ impl Command for StartCommand {
          Otherwise, use 0.0.0.0/0 (redirect the whole traffic).\n\
          If -p is given, then make the relay server listen on the specified\n\
          port. Otherwise, use port 31416.\n\
+         If -e is given, then exclude the specified domains from being proxied.\n\
          If the client is already started, then do nothing, and ignore\n\
          the other parameters.\n\
          10.0.2.2 is mapped to the host 'localhost'."
@@ -228,6 +233,7 @@ impl Command for StartCommand {
             args.dns_servers(),
             args.routes(),
             args.port(),
+            args.exclusion_list(),
         )
     }
 }
@@ -239,6 +245,7 @@ impl Command for AutostartCommand {
 
     fn accepted_parameters(&self) -> u8 {
         cli_args::PARAM_DNS_SERVERS | cli_args::PARAM_ROUTES | cli_args::PARAM_PORT
+            | cli_args::PARAM_EXCLUSION_LIST
     }
 
     fn description(&self) -> &'static str {
@@ -249,7 +256,7 @@ impl Command for AutostartCommand {
     }
 
     fn execute(&self, args: &CommandLineArguments) -> Result<(), CommandExecutionError> {
-        cmd_autostart(args.dns_servers(), args.routes(), args.port())
+        cmd_autostart(args.dns_servers(), args.routes(), args.port(), args.exclusion_list())
     }
 }
 
@@ -283,6 +290,7 @@ impl Command for RestartCommand {
             | cli_args::PARAM_DNS_SERVERS
             | cli_args::PARAM_ROUTES
             | cli_args::PARAM_PORT
+            | cli_args::PARAM_EXCLUSION_LIST
     }
 
     fn description(&self) -> &'static str {
@@ -296,6 +304,7 @@ impl Command for RestartCommand {
             args.dns_servers(),
             args.routes(),
             args.port(),
+            args.exclusion_list(),
         )?;
         Ok(())
     }
@@ -362,9 +371,10 @@ fn cmd_run(
     dns_servers: Option<&str>,
     routes: Option<&str>,
     port: u16,
+    exclusion_list: Option<&str>,
 ) -> Result<(), CommandExecutionError> {
     // start in parallel so that the relay server is ready when the client connects
-    async_start(serial, dns_servers, routes, port);
+    async_start(serial, dns_servers, routes, port, exclusion_list);
 
     let ctrlc_serial = serial.map(String::from);
     ctrlc::set_handler(move || {
@@ -386,14 +396,17 @@ fn cmd_autorun(
     dns_servers: Option<&str>,
     routes: Option<&str>,
     port: u16,
+    exclusion_list: Option<&str>,
 ) -> Result<(), CommandExecutionError> {
     {
         let autostart_dns_servers = dns_servers.map(String::from);
         let autostart_routes = routes.map(String::from);
+        let autostart_exclusion_list = exclusion_list.map(String::from);
         thread::spawn(move || {
             let dns_servers = autostart_dns_servers.as_ref().map(String::as_ref);
             let routes = autostart_routes.as_ref().map(String::as_ref);
-            if let Err(err) = cmd_autostart(dns_servers, routes, port) {
+            let exclusion_list = autostart_exclusion_list.as_ref().map(String::as_ref);
+            if let Err(err) = cmd_autostart(dns_servers, routes, port, exclusion_list) {
                 error!(target: TAG, "Cannot auto start clients: {}", err);
             }
         });
@@ -407,6 +420,7 @@ fn cmd_start(
     dns_servers: Option<&str>,
     routes: Option<&str>,
     port: u16,
+    exclusion_list: Option<&str>,
 ) -> Result<(), CommandExecutionError> {
     if must_install_client(serial)? {
         cmd_install(serial)?;
@@ -433,6 +447,9 @@ fn cmd_start(
     if let Some(routes) = routes {
         adb_args.append(&mut vec!["--esa", "routes", routes]);
     }
+    if let Some(exclusion_list) = exclusion_list {
+        adb_args.append(&mut vec!["--esa", "proxyExclusionList", exclusion_list]);
+    }
     exec_adb(serial, adb_args)
 }
 
@@ -440,13 +457,16 @@ fn cmd_autostart(
     dns_servers: Option<&str>,
     routes: Option<&str>,
     port: u16,
+    exclusion_list: Option<&str>,
 ) -> Result<(), CommandExecutionError> {
     let start_dns_servers = dns_servers.map(String::from);
     let start_routes = routes.map(String::from);
+    let start_exclusion_list = exclusion_list.map(String::from);
     let mut adb_monitor = AdbMonitor::new(Box::new(move |serial: &str| {
         let dns_servers = start_dns_servers.as_ref().map(String::as_ref);
         let routes = start_routes.as_ref().map(String::as_ref);
-        async_start(Some(serial), dns_servers, routes, port)
+        let exclusion_list = start_exclusion_list.as_ref().map(String::as_ref);
+        async_start(Some(serial), dns_servers, routes, port, exclusion_list)
     }));
     adb_monitor.monitor();
     Ok(())
@@ -485,15 +505,17 @@ fn cmd_relay(port: u16) -> Result<(), CommandExecutionError> {
     Ok(())
 }
 
-fn async_start(serial: Option<&str>, dns_servers: Option<&str>, routes: Option<&str>, port: u16) {
+fn async_start(serial: Option<&str>, dns_servers: Option<&str>, routes: Option<&str>, port: u16, exclusion_list: Option<&str>) {
     let start_serial = serial.map(String::from);
     let start_dns_servers = dns_servers.map(String::from);
     let start_routes = routes.map(String::from);
+    let start_exclusion_list = exclusion_list.map(String::from);
     thread::spawn(move || {
         let serial = start_serial.as_ref().map(String::as_ref);
         let dns_servers = start_dns_servers.as_ref().map(String::as_ref);
         let routes = start_routes.as_ref().map(String::as_ref);
-        if let Err(err) = cmd_start(serial, dns_servers, routes, port) {
+        let exclusion_list = start_exclusion_list.as_ref().map(String::as_ref);
+        if let Err(err) = cmd_start(serial, dns_servers, routes, port, exclusion_list) {
             error!(target: TAG, "Cannot start client: {}", err);
         }
     });
@@ -604,6 +626,9 @@ fn append_command_usage(msg: &mut String, command: &dyn Command) {
     }
     if (accepted_parameters & cli_args::PARAM_ROUTES) != 0 {
         msg.push_str(" [-r ROUTE[,ROUTE2,...]]");
+    }
+    if (accepted_parameters & cli_args::PARAM_EXCLUSION_LIST) != 0 {
+        msg.push_str(" [-e EXCLUDE[,EXCLUDE2,...]]");
     }
     msg.push('\n');
     for desc_line in command.description().split('\n') {


### PR DESCRIPTION
This PR adds support for HTTP proxy exclusion list as requested in issue #482.

## Summary
- Add proxyExclusionList field to VpnConfiguration
- Add EXTRA_PROXY_EXCLUSION_LIST to GnirehtetActivity  
- Add setupHttpProxy() method in GnirehtetService using VpnService.Builder.setHttpProxy()
- Add -x host:port and -e exclusion-list command line options for both Java and Rust CLIs

## Usage
```
# Exclude specific domains from proxy
gnirehtet run -x proxy.example.com:8080 -e "domain1.com,domain2.com"
```

## Requirements
- Requires Android 10 (API 29) or higher for proxy exclusion list feature

This allows users to exclude certain domains from being proxied through gnirehtet, solving issue #482 where users need to bypass the proxy for specific websites while using the Android global HTTP proxy.